### PR TITLE
Update logic so that it checks multiple conditions before returning

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -61,16 +61,15 @@ class PullRequest(object):
         try:
             labels_json = self.labels
             labels_list = [l['name'] for l in labels_json]
+            valid = True
 
-            if required_any is not None and any(l in required_any for l in labels_list):
-                return True
-            if required_any is not None and not any(l in required_any for l in labels_list):
-                return False
             if required_all is not None and any(l not in labels_list for l in required_all):
-                return False
+                valid = False
+            if required_any is not None and any(l in required_any for l in labels_list):
+                valid = True
             if banned is not None and any(l in labels_list for l in banned):
-                return False
-            return True
+                valid = False
+            return valid
         except TypeError:
             print('self.labels was of unexpected format for PR event {}: {}'.format(self.issue_url, labels_json))
             return False


### PR DESCRIPTION
Here is the logic flow after these changes.

1. Checks to see if all required labels are added, if not sets return value to `False`
2. Checks to see if one of the any labels has been added, if so sets return value back to `True`
3. Checks to see if a banned label has been added, if so sets return value to `False`
4. Returns value

- `['qa-approved', 'product-approved', 'design-approved']` - passes
- `['qa-approved', 'product-approved']` - fails
- `['developer-facing']` - passes
- `['qa-approved', 'product-approved', 'design-approved', 'banned-label']` - fails
